### PR TITLE
chore(deps): update actions/checkout action to v4

### DIFF
--- a/.github/workflows/auto-delete-cache.yml
+++ b/.github/workflows/auto-delete-cache.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup
         run: |

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,7 +6,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Cache Cargo Dependencies
       uses: actions/cache@v3


### PR DESCRIPTION
## WHAT

renovate が入っていなかったので，人間 renovate をやりにきた．`actions/checkout` の v4 がリリースされていたので全部あげる．

リリース: https://github.com/actions/checkout/releases/tag/v4.0.0


